### PR TITLE
Get rid of php7 double question operand to keep compatibility with ph…

### DIFF
--- a/src/Locale/Route.php
+++ b/src/Locale/Route.php
@@ -24,9 +24,9 @@ class Route
         $currentRouteName = $currentRoute ? $currentRoute->getName() : '';
         $currentRouteParameters = $currentRoute ? $currentRoute->parameters() : [];
 
-        $locale = $locale ?? App::getLocale();
-        $name = $name ?? $currentRouteName;
-        $parameters = $parameters ?? $currentRouteParameters;
+        $locale = $locale != null ? $locale : App::getLocale();
+        $name = $name != null ? $name : $currentRouteName;
+        $parameters = $parameters != null ? $parameters : $currentRouteParameters;
 
         $localeRoute = $this->switchLocale($locale, $name);
         $localeUrl = $this->url->route($localeRoute, $parameters, $absolute);
@@ -50,7 +50,7 @@ class Route
         return $unlocaleRoute;
     }
 
-    public function getLocalePrefix(string $route)
+    public function getLocalePrefix($route)
     {
         foreach ($this->locales() as $locale) {
             $localePrefix = $locale . '.';
@@ -72,5 +72,4 @@ class Route
     {
         return $locale . '.' . $route;
     }
-
 }

--- a/src/Locale/Route.php
+++ b/src/Locale/Route.php
@@ -26,7 +26,7 @@ class Route
 
         $locale = $locale ?? App::getLocale();
         $name = $name ?? $currentRouteName;
-        $parameters = $parameters ?? $currentRouteParameters;
+        $parameters = isset($parameters) ? $parameters : $currentRouteParameters;
 
         $localeRoute = $this->switchLocale($locale, $name);
         $localeUrl = $this->url->route($localeRoute, $parameters, $absolute);

--- a/src/Locale/Url.php
+++ b/src/Locale/Url.php
@@ -16,7 +16,7 @@ class Url
 
     public function getRouteUrl($locale, $route, array $urls = [])
     {
-        $unlocaleUrl = $urls[$locale] ?? $this->translator->get('routes.' . $route, [], $locale);
+        $unlocaleUrl = isset($urls[$locale]) ? $urls[$locale] : $this->translator->get('routes.' . $route, [], $locale);
         $url = $this->addLocale($locale, $unlocaleUrl);
         return $url;
     }

--- a/src/Middleware/SetLocale.php
+++ b/src/Middleware/SetLocale.php
@@ -27,5 +27,4 @@ class SetLocale
 
         return $next($request);
     }
-
 }

--- a/src/Middleware/SetSessionLocale.php
+++ b/src/Middleware/SetSessionLocale.php
@@ -28,5 +28,4 @@ class SetSessionLocale
 
         return $next($request);
     }
-
 }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -68,7 +68,7 @@ class Router
     {
         $url = $this->localeUrl->getRouteUrl($locale, $route, $urls);
         $localeAction = $this->addLocaleRouteToAction($locale, $route, $action);
-        $middleware = $this->addSetSessionLocaleMiddleware($locale, $urls['middleware'] ?? []);
+        $middleware = $this->addSetSessionLocaleMiddleware($locale, isset($urls['middleware']) ? $urls['middleware'] : []);
 
         $this->laravelRouter
             ->$method($url, $localeAction)
@@ -106,7 +106,7 @@ class Router
 
     protected function addLocaleAs($locale, array $attributes)
     {
-        $as = $attributes['as'] ?? '';
+        $as = isset($attributes['as']) ? $attributes['as'] : '';
         $as = $this->localeRoute->addLocale($locale, $as);
         $attributes['as'] = $as;
 
@@ -115,7 +115,7 @@ class Router
 
     protected function addLocalePrefix($locale, array $attributes)
     {
-        $prefix = $attributes['prefix'] ?? '';
+        $prefix = isset($attributes['prefix']) ? $attributes['prefix'] : '';
         $prefix = $this->localeUrl->addLocale($locale, $prefix);
         $prefix = rtrim($prefix, '/');
         $attributes['prefix'] = $prefix;
@@ -125,7 +125,7 @@ class Router
 
     protected function addSetSessionLocaleMiddlewareToAttributes($locale, array $attributes)
     {
-        $middleware = $attributes['middleware'] ?? [];
+        $middleware = isset($attributes['middleware']) ? $attributes['middleware'] : [];
         $attributes['middleware'] = $this->addSetSessionLocaleMiddleware($locale, $middleware);
 
         return $attributes;
@@ -146,5 +146,4 @@ class Router
             $this->laravelRouter->resource($localeName, $controller, $options);
         }
     }
-
 }

--- a/tests/Functional/HelpersTest.php
+++ b/tests/Functional/HelpersTest.php
@@ -29,7 +29,9 @@ class HelpersTest extends TestCase
 
     public function testLocaleRoute()
     {
-        LocaleRoute::get('route', function () {return 'route';}, ['fr' => 'route_fr', 'en' => 'route_en']);
+        LocaleRoute::get('route', function () {
+            return 'route';
+        }, ['fr' => 'route_fr', 'en' => 'route_en']);
 
         $this->assertSame(url('fr/route_fr'), locale_route('fr', 'route'));
         $this->assertSame(url('en/route_en'), locale_route('en', 'route'));
@@ -37,7 +39,9 @@ class HelpersTest extends TestCase
 
     public function testOtherLocaleWithDefaultParameters()
     {
-        LocaleRoute::get('article.show', function () {return 'route';}, ['fr' => 'article/{id}', 'en' => 'article/{id}']);
+        LocaleRoute::get('article.show', function () {
+            return 'route';
+        }, ['fr' => 'article/{id}', 'en' => 'article/{id}']);
 
         $response = $this->call('get', 'fr/article/2');
 
@@ -47,7 +51,9 @@ class HelpersTest extends TestCase
 
     public function testLocaleRouteWithDefaultParameters()
     {
-        LocaleRoute::get('article.show', function () {return 'route';}, ['fr' => 'article/{id}', 'en' => 'article/{id}']);
+        LocaleRoute::get('article.show', function () {
+            return 'route';
+        }, ['fr' => 'article/{id}', 'en' => 'article/{id}']);
 
         $response = $this->call('get', 'fr/article/2');
 

--- a/tests/Functional/HelpersTest.php
+++ b/tests/Functional/HelpersTest.php
@@ -45,6 +45,16 @@ class HelpersTest extends TestCase
         $this->assertSame(url('en/article/2'), other_locale('en'));
     }
 
+    public function testAnotherRouteWithEmptyParameters()
+    {
+        LocaleRoute::get('article.show', function () {return 'route';}, ['fr' => 'article/{param}', 'en' => 'article/{param}']);
+        LocaleRoute::get('articles', function () {return 'route';}, ['fr' => 'articles', 'en' => 'articles']);
+
+        $response = $this->call('get', other_route('article.show', 'foobar'));
+
+        $this->assertSame(url('en/articles'), other_route('articles', []));
+    }
+
     public function testLocaleRouteWithDefaultParameters()
     {
         LocaleRoute::get('article.show', function () {return 'route';}, ['fr' => 'article/{id}', 'en' => 'article/{id}']);

--- a/tests/Functional/Session/LocaleTest.php
+++ b/tests/Functional/Session/LocaleTest.php
@@ -34,5 +34,4 @@ class LocaleTest extends TestCase
         $this->assertSame($fallbackLocale, $this->locale->get());
         $this->assertSame($fallbackLocale, app()->getLocale());
     }
-
 }

--- a/tests/Unit/Locale/RouteTest.php
+++ b/tests/Unit/Locale/RouteTest.php
@@ -143,5 +143,4 @@ class RouteTest extends TestCase
 
         $this->assertSame($locale . '.' . $route, $this->localizer->addLocale($locale, $route));
     }
-
 }

--- a/tests/Unit/Routing/RouterTest.php
+++ b/tests/Unit/Routing/RouterTest.php
@@ -178,7 +178,8 @@ class RouterTest extends TestCase
     public function testGroupWithNoHasAttribute()
     {
         $attributes = ['prefix' => 'url', 'middleware' => 'auth'];
-        $callback = function () {};
+        $callback = function () {
+        };
 
         foreach ($this->locales as $locale) {
             $newAttributes = ['as' => $locale . '.', 'prefix' => $locale . '/url', 'middleware' => ['auth', SetSessionLocale::class . ':' . $locale]];
@@ -193,7 +194,8 @@ class RouterTest extends TestCase
     {
         $route = 'route';
         $attributes = ['as' => $route, 'prefix' => 'url', 'middleware' => 'auth'];
-        $callback = function () {};
+        $callback = function () {
+        };
 
         foreach ($this->locales as $locale) {
             $newAttributes = ['as' => $locale . '.' . $route, 'prefix' => $locale . '/url', 'middleware' => ['auth', SetSessionLocale::class . ':' . $locale]];
@@ -217,6 +219,5 @@ class RouterTest extends TestCase
         }
 
         $this->localeRouter->resource($name, $controller, $options);
-
     }
 }

--- a/tests/Unit/Session/LocaleTest.php
+++ b/tests/Unit/Session/LocaleTest.php
@@ -46,5 +46,4 @@ class LocaleTest extends TestCase
 
         $this->assertSame($this->fallbackLocale, $this->locale->get());
     }
-
 }


### PR DESCRIPTION
## Description

I remove "??" operand to make this package compatible with php5.6.

## Motivation and context

Operand "??" is just small decorative thing and without it many people are able to use package on php5.6. Maybe it could be kept in another branch, if something breakable will be used from php7 without possibility of inverse implementation.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
- [x] My code follows the code style of this project.